### PR TITLE
Add gallery of preview images

### DIFF
--- a/docs/_sass/jekyll-theme-hacker.scss
+++ b/docs/_sass/jekyll-theme-hacker.scss
@@ -267,3 +267,12 @@ a {
 #a-title {
   text-decoration: none;
 }
+
+table.gallery td {
+  text-align: center;
+}
+
+table.gallery img {
+  height: 10em;
+  width: auto;
+}

--- a/docs/gallery/index.html
+++ b/docs/gallery/index.html
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Where are they now?
+---
+
+<h1>{{ page.title }}</h1>
+
+<p>
+Click an image to find out
+
+<p>
+<table class="gallery">
+  {% tablerow suspect in site.suspects cols:4 %}
+  <a href="{{ suspect.url }}">
+    <img src="{{ suspect.image }}" alt="{{ suspect.name }}" title="{{ suspect.name }}">
+  </a>
+  {% endtablerow %}
+</table>


### PR DESCRIPTION
This uses tables and is not very responsive. Will redesign later to use css and flow better.

Uses `suspect.image` field, which is a full url to prod site. If we prefer relative links, we could change the field values to be relative, or add a hack to parse the path out of the field.
